### PR TITLE
Bugfix: fix bug on large directory

### DIFF
--- a/src/path_x.cxx
+++ b/src/path_x.cxx
@@ -39,7 +39,7 @@ PathX::PathX(const char* path) : std::filesystem::path(path)
 //   (std::vector<std::string>): List of names of the entries.
 //
 std::vector<std::string>
-PathX::listdir(void)
+PathX::listdir(uint32_t n_max_items)
 const noexcept
 {
     // Initilize returned vector.
@@ -64,6 +64,12 @@ const noexcept
 
         // Add to the returned vector.
         result.push_back(path_relative.string() + (entry.is_directory() ? "/" : ""));
+
+        // Stop directory search if exceeds the maximum number of items.
+        // Becase it taks too long time for seaching a big directory and
+        // it tend to prevent user's confortable command editing.
+        if (result.size() > n_max_items)
+            break;
     }
 
     // Define sorting key function.

--- a/src/path_x.hxx
+++ b/src/path_x.hxx
@@ -31,7 +31,7 @@ class PathX : public std::filesystem::path
 
         // Returns a list of names of the entries in the given directory path.
         std::vector<std::string>
-        listdir(void)
+        listdir(uint32_t n_max_items = 128)
         const noexcept;
 };
 


### PR DESCRIPTION
### Issue

* NiShiKi freeze when complete contents of a directory which contains many files (e.g. more than 10,000).
* This is cased by `EditHelper.cands_filepath` and `PathX.listdir` functions.

### Solution

* Apply upper limit for the number of searched files to the function `pathX.listdir`.

